### PR TITLE
[power] Do not enable panel if the new setting 'disable-display-wake' is true 

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,8 @@ schemas = [
   'org.gnome.settings-daemon.plugins.media-keys.gschema.xml',
   'org.gnome.settings-daemon.plugins.power.gschema.xml',
   'org.gnome.settings-daemon.plugins.sharing.gschema.xml',
-  'org.gnome.settings-daemon.plugins.xsettings.gschema.xml'
+  'org.gnome.settings-daemon.plugins.xsettings.gschema.xml',
+  'org.droidian.settings-daemon.power.gschema.xml'
 ]
 
 if enable_wwan

--- a/data/org.droidian.settings-daemon.power.gschema.xml.in
+++ b/data/org.droidian.settings-daemon.power.gschema.xml.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.droidian.settings-daemon.power" path="/org/droidian/settings-daemon/power/">
+    <key name="disable-display-wake" type="b">
+      <default>true</default>
+      <summary>Disables enabling display on wakeup from suspend</summary>
+      <description>If the display should not be woken up on resume from suspend. On a mobile device you most likely want to enable this.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -2248,6 +2248,10 @@ engine_session_properties_changed_cb (GDBusProxy      *session,
                                       GsdPowerManager *manager)
 {
         GVariant *v;
+        gboolean display_wake_disabled;
+
+        display_wake_disabled = g_settings_get_boolean (manager->settings_droidian_power,
+                                                        "disable-display-wake");
 
         v = g_variant_lookup_value (changed, "SessionIsActive", G_VARIANT_TYPE_BOOLEAN);
         if (v) {
@@ -2258,7 +2262,7 @@ engine_session_properties_changed_cb (GDBusProxy      *session,
                 manager->session_is_active = active;
                 /* when doing the fast-user-switch into a new account,
                  * ensure the new account is undimmed and with the backlight on */
-                if (active) {
+                if (active && !display_wake_disabled) {
                         idle_set_mode (manager, GSD_POWER_IDLE_MODE_NORMAL);
                         iio_proxy_claim_light (manager, TRUE);
                 } else {
@@ -2451,7 +2455,8 @@ static void
 handle_resume_actions (GsdPowerManager *manager)
 {
         /* ensure we turn the panel back on after resume */
-        backlight_enable (manager);
+        if (!g_settings_get_boolean (manager->settings_droidian_power, "disable-display-wake"))
+            backlight_enable (manager);
 
         /* set up the delay again */
         inhibit_suspend (manager);

--- a/plugins/power/gsd-power-manager.c
+++ b/plugins/power/gsd-power-manager.c
@@ -144,6 +144,7 @@ struct _GsdPowerManager
         GSettings               *settings;
         GSettings               *settings_bus;
         GSettings               *settings_screensaver;
+        GSettings               *settings_droidian_power;
 
         /* Screensaver */
         GsdScreenSaver          *screensaver_proxy;
@@ -2738,6 +2739,7 @@ gsd_power_manager_start (GsdPowerManager *manager,
         manager->settings = g_settings_new (GSD_POWER_SETTINGS_SCHEMA);
         manager->settings_screensaver = g_settings_new ("org.gnome.desktop.screensaver");
         manager->settings_bus = g_settings_new ("org.gnome.desktop.session");
+        manager->settings_droidian_power = g_settings_new ("org.droidian.settings-daemon.power");
 
         /* setup ambient light support */
         manager->iio_proxy_watch_id =
@@ -2782,6 +2784,7 @@ gsd_power_manager_stop (GsdPowerManager *manager)
         g_clear_object (&manager->settings);
         g_clear_object (&manager->settings_screensaver);
         g_clear_object (&manager->settings_bus);
+        g_clear_object (&manager->settings_droidian_power);
         g_clear_object (&manager->up_client);
 
         iio_proxy_claim_light (manager, FALSE);


### PR DESCRIPTION
Mobile devices sleep most of the time and may wakeup from sleep
without user input to execute background tasks.

In these cases, we shouldn't really enable the display. This
setting, introduced in a GSettings schema included in this Pull Request,
will force the display to stay shut on wakeups.